### PR TITLE
fix: Missing include <atomic>

### DIFF
--- a/src/game/object/creature.h
+++ b/src/game/object/creature.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <queue>
 
 #include "../../resources/2dafile.h"


### PR DESCRIPTION
Fixes build on Gentoo Linux with gcc-10.2.0