### PR TITLE
chore: Accept moved or copied Action in Creature::enqueueAction

### DIFF
--- a/src/game/object/creature.cpp
+++ b/src/game/object/creature.cpp
@@ -253,8 +253,8 @@ void Creature::clearActions() {
     _actions.clear();
 }
 
-void Creature::enqueueAction(const Action &action) {
-    _actions.push_back(action);
+void Creature::enqueueAction(Action action) {
+    _actions.emplace_back(std::move(action));
 }
 
 void Creature::popCurrentAction() {

--- a/src/game/object/creature.h
+++ b/src/game/object/creature.h
@@ -102,7 +102,7 @@ public:
 
     // Actions
     void clearActions();
-    void enqueueAction(const Action &action);
+    void enqueueAction(Action action);
     void popCurrentAction();
 
     // Load/save


### PR DESCRIPTION
Callers of Creature::enqueueAction (such as some methods in game/script/routines_common.cpp) often try to perform a move, but since the old Creature::enqueueAction accepted only a const ref, it ended up copying instead of moving.

This fixes that, and allows for both copies and moves into Creature::enqueueAction.