### PR TITLE
Fix rendering on intel mesa

### DIFF
--- a/src/render/framebuffer.cpp
+++ b/src/render/framebuffer.cpp
@@ -45,8 +45,8 @@ void Framebuffer::init() {
         glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _width, _height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
         glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
         glBindTexture(GL_TEXTURE_2D, 0);
     }
     glGenRenderbuffers(1, &_depthBuffer);

--- a/src/render/pipeline/world.cpp
+++ b/src/render/pipeline/world.cpp
@@ -135,19 +135,18 @@ void WorldRenderPipeline::render() const {
         LocalUniforms locals;
         locals.model = move(transform);
         locals.features.bloomEnabled = true;
-        locals.textures.bloom = 1;
 
         Shaders::instance().activate(ShaderProgram::GUIBloom, locals);
 
         glActiveTexture(GL_TEXTURE0);
         _geometry.bindColorBuffer(0);
 
-        glActiveTexture(GL_TEXTURE1);
+        glActiveTexture(GL_TEXTURE0 + locals.textures.bloom);
         _verticalBlur.bindColorBuffer(0);
 
         Quad::getDefault().renderTriangles();
 
-        glActiveTexture(GL_TEXTURE1);
+        glActiveTexture(GL_TEXTURE + locals.textures.bloom);
         _verticalBlur.unbindColorBuffer();
 
         glActiveTexture(GL_TEXTURE0);

--- a/src/render/shaders.cpp
+++ b/src/render/shaders.cpp
@@ -434,19 +434,12 @@ void Shaders::setLocalUniforms(const LocalUniforms &locals) {
     setUniform("uLightingEnabled", locals.features.lightingEnabled);
     setUniform("uSelfIllumEnabled", locals.features.selfIllumEnabled);
     setUniform("uDiscardEnabled", locals.features.discardEnabled);
+    setUniform("uLightmap", locals.textures.lightmap);
+    setUniform("uEnvmap", locals.textures.envmap);
+    setUniform("uBumpyShiny", locals.textures.bumpyShiny);
+    setUniform("uBumpmap", locals.textures.bumpmap);
+    setUniform("uBloom", locals.textures.bloom);
 
-    if (locals.features.lightmapEnabled) {
-        setUniform("uLightmap", locals.textures.lightmap);
-    }
-    if (locals.features.envmapEnabled) {
-        setUniform("uEnvmap", locals.textures.envmap);
-    }
-    if (locals.features.bumpyShinyEnabled) {
-        setUniform("uBumpyShiny", locals.textures.bumpyShiny);
-    }
-    if (locals.features.bumpmapEnabled) {
-        setUniform("uBumpmap", locals.textures.bumpmap);
-    }
     if (locals.features.skeletalEnabled) {
         setUniform("uAbsTransform", locals.skeletal.absTransform);
         setUniform("uAbsTransformInv", locals.skeletal.absTransformInv);
@@ -470,9 +463,6 @@ void Shaders::setLocalUniforms(const LocalUniforms &locals) {
     if (locals.features.blurEnabled) {
         setUniform("uResolution", locals.blur.resolution);
         setUniform("uDirection", locals.blur.direction);
-    }
-    if (locals.features.bloomEnabled) {
-        setUniform("uBloom", locals.textures.bloom);
     }
     if (locals.features.discardEnabled) {
         setUniform("uDiscardColor", locals.discardColor);

--- a/src/render/shaders.h
+++ b/src/render/shaders.h
@@ -59,11 +59,11 @@ struct FeatureUniforms {
 };
 
 struct TextureUniforms {
-    int lightmap { 0 };
-    int envmap { 0 };
-    int bumpyShiny { 0 };
-    int bumpmap { 0 };
-    int bloom { 0 };
+    static constexpr int envmap { 1 };
+    static constexpr int lightmap { 2 };
+    static constexpr int bumpyShiny { 3 };
+    static constexpr int bumpmap { 4 };
+    static constexpr int bloom { 5 };
 };
 
 struct SkeletalUniforms {

--- a/src/scene/modelnodescenenode.cpp
+++ b/src/scene/modelnodescenenode.cpp
@@ -73,19 +73,15 @@ void ModelNodeSceneNode::renderSingle() const {
 
     if (mesh->hasEnvmapTexture()) {
         locals.features.envmapEnabled = true;
-        locals.textures.envmap = 1;
     }
     if (mesh->hasLightmapTexture()) {
         locals.features.lightmapEnabled = true;
-        locals.textures.lightmap = 2;
     }
     if (mesh->hasBumpyShinyTexture()) {
         locals.features.bumpyShinyEnabled = true;
-        locals.textures.bumpyShiny = 3;
     }
     if (mesh->hasBumpmapTexture()) {
         locals.features.bumpmapEnabled = true;
-        locals.textures.bumpmap = 4;
     }
     if (skeletal) {
         locals.features.skeletalEnabled = true;


### PR DESCRIPTION
Rendering on Intel was broken because of multiple sampler types pointing to the same texture unit. So it seems like texture sampler uniforms always needs to be initialized.

With this change they always get set and always uses the same texture units for each type.

Idk if this is the best way to fix it, but it was quick and easy.

Also a fix for an invalid enum error with glTexParameteri.