### PR TITLE
Implement portrait click actions

### DIFF
--- a/src/engine/game/gui/hud.cpp
+++ b/src/engine/game/gui/hud.cpp
@@ -328,6 +328,11 @@ void HUD::onClick(const string &control) {
                 break;
             }
         }
+    } else if (control == "BTN_CHAR1") {
+        _game->openInGameMenu(InGameMenu::Tab::Equipment);
+    } else if (control == "BTN_CHAR2" || control == "BTN_CHAR3") {
+        int memberIdx = 4 - stoi(&control[8]);
+        _game->party().setPartyLeaderByIndex(memberIdx);
     }
 }
 

--- a/src/engine/game/party.cpp
+++ b/src/engine/game/party.cpp
@@ -187,14 +187,7 @@ void Party::setPartyLeader(int npc) {
 }
 
 void Party::setPartyLeaderByIndex(int index) {
-    if (index == 0) {
-        warn("Party: attempted to switch leader to current party member: " + to_string(index));
-        return;
-    }
-    if (index >= _members.size()) {
-        warn("Party: index out of range: " + to_string(index));
-        return;
-    }
+    if (index < 1 || index >= _members.size()) return;
 
     Member tmp(_members[0]);
     _members[0] = _members[index];

--- a/src/engine/game/party.cpp
+++ b/src/engine/game/party.cpp
@@ -183,9 +183,22 @@ void Party::setPartyLeader(int npc) {
     }
     if (memberIdx == 0) return;
 
+    setPartyLeaderByIndex(memberIdx);
+}
+
+void Party::setPartyLeaderByIndex(int index) {
+    if (index == 0) {
+        warn("Party: attempted to switch leader to current party member: " + to_string(index));
+        return;
+    }
+    if (index >= _members.size()) {
+        warn("Party: index out of range: " + to_string(index));
+        return;
+    }
+
     Member tmp(_members[0]);
-    _members[0] = _members[memberIdx];
-    _members[memberIdx] = tmp;
+    _members[0] = _members[index];
+    _members[index] = tmp;
 
     onLeaderChanged();
 }

--- a/src/engine/game/party.h
+++ b/src/engine/game/party.h
@@ -53,6 +53,7 @@ public:
     std::shared_ptr<Creature> player() const { return _player; }
 
     void setPartyLeader(int npc);
+    void setPartyLeaderByIndex(int index);
     void setPlayer(const std::shared_ptr<Creature> &player);
     void setSoloMode(bool value) { _solo = value; }
 


### PR DESCRIPTION
I've added the click handlers for the portraits in the main gameplay HUD. As in vanilla, clicking on the leader's portrait will open the equipment menu, while clicking on a companion's portrait will make that member the party leader.