### PR TITLE
Add install commands to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -675,9 +675,9 @@ else()
     target_link_libraries(reone PRIVATE ${SDL2_LIBRARIES} ${OpenAL_LIBRARIES} Threads::Threads -latomic)
 endif()
 
-## END reone executable
-
 list(APPEND InstallTargets reone)
+
+## END reone executable
 
 ## reone-tools executable
 
@@ -775,9 +775,13 @@ endif()
 
 ## END Unit tests
 
+## Installation
+
 if(UNIX AND NOT APPLE)
     include(GNUInstallDirs)
 endif()
 
 install(TARGETS ${InstallTargets} DESTINATION ${CMAKE_INSTALL_BINDIR})
 install(TARGETS libcommon libresource libgraphics libaudio libvideo libscript libgame DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+## END Installation

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,6 +677,8 @@ endif()
 
 ## END reone executable
 
+list(APPEND InstallTargets reone)
+
 ## reone-tools executable
 
 if(BUILD_TOOLS)
@@ -714,6 +716,7 @@ if(BUILD_TOOLS)
     else()
         target_link_libraries(reone PRIVATE ${SDL2_LIBRARIES})
     endif()
+    list(APPEND InstallTargets reone-tools)
 endif()
 
 ## END reone-tools executable
@@ -741,6 +744,7 @@ if(BUILD_LAUNCHER)
         target_link_libraries(reone-launcher ${wxWidgets_LIBRARIES} ${Boost_FILESYSTEM_LIBRARY} ${Boost_PROGRAM_OPTIONS_LIBRARY} ${Boost_SYSTEM_LIBRARY})
 
         set_target_properties(reone-launcher PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+        list(APPEND InstallTargets reone-launcher)
     else()
         message(WARNING "wxWidgets not found - launcher cannot be built")
     endif()
@@ -770,3 +774,10 @@ if(BUILD_TESTS)
 endif()
 
 ## END Unit tests
+
+if(UNIX AND NOT APPLE)
+    include(GNUInstallDirs)
+endif()
+
+install(TARGETS ${InstallTargets} DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS libcommon libresource libgraphics libaudio libvideo libscript libgame DESTINATION ${CMAKE_INSTALL_LIBDIR})


### PR DESCRIPTION
These additions allow you to run the following: 

```
cmake --build . --target INSTALL
```

... which will build the project, and then put the executables and libs into the system's PATH. On Windows, this means it will move the executable and dll files to `C:\Program Files (x86)\reone` and on Linux they'll go to `/usr/local/bin` and `/usr/local/lib`, respectively. 