### PR TITLE
Update minimum required cmake version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
-cmake_minimum_required(VERSION 3.10)
+cmake_minimum_required(VERSION 3.16)
 project(reone)
 
 set(CMAKE_CXX_STANDARD 14)


### PR DESCRIPTION
`target_precompile_headers` was introduced in cmake 3.16 according to the [docs](https://cmake.org/cmake/help/latest/command/target_precompile_headers.html)

Signed-off-by: William Brawner <me@wbrawner.com>