### PR TITLE
fix font out of bounds exception for non ascii chars

### DIFF
--- a/src/libs/graphics/font.cpp
+++ b/src/libs/graphics/font.cpp
@@ -117,8 +117,9 @@ glm::vec2 Font::getTextOffset(const std::string &text, TextGravity gravity) cons
 
 float Font::measure(const std::string &text) const {
     float w = 0.0f;
-    for (auto &glyph : text) {
-        w += _glyphs[static_cast<int>(glyph)].size.x;
+    for (int i = 0; i < text.size(); i++) {
+        auto ustr = reinterpret_cast<const unsigned char *>(text.c_str());
+        w += _glyphs.at(ustr[i]).size.x;
     }
     return w;
 }


### PR DESCRIPTION
This fixes an out of bounds exception for non-ascii characters

![image](https://github.com/user-attachments/assets/b46b4f9d-7f68-4816-802f-9d67f3e0a1f7)
